### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,7 @@
     ],
     "depends": [],
     "perl": 6,
-    "license": "http://www.perlfoundation.org/artistic_license_2_0",
+    "license": "Artistic-2.0",
     "support": {
       "source": "https://github.com/skids/perl6-Control-Bail.git"
     },


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license